### PR TITLE
Revamp experience content and repair portfolio navigation

### DIFF
--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -7,12 +7,13 @@ export default function About() {
   return (
     <motion.section
       id="about"
-      className="py-32 px-6 bg-white dark:bg-black text-center"
+      className="py-32 px-6 text-center text-slate-900 dark:text-slate-100"
       initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
       transition={{ duration: 0.8 }}
     >
-      <h2 className="text-5xl font-bold mb-10 text-black dark:text-white">Who Am I?</h2>
+      <h2 className="text-5xl font-bold mb-10 text-slate-900 dark:text-white">Who Am I?</h2>
       <div className="flex flex-col md:flex-row items-center justify-center max-w-6xl mx-auto gap-16">
         {/* Profile Image */}
         <div className="relative w-56 h-56 md:w-72 md:h-72 flex-shrink-0 rounded-full overflow-hidden shadow-lg">
@@ -25,22 +26,22 @@ export default function About() {
         </div>
 
         {/* About Content */}
-        <div className="text-left max-w-2xl space-y-6">
-          <p className="text-xl text-gray-700 dark:text-gray-300 leading-relaxed">
+          <div className="text-left max-w-2xl space-y-6">
+            <p className="text-xl text-slate-700 dark:text-slate-300 leading-relaxed">
             Hi! I&apos;m <span className="font-bold">Rakshith Roy Gantagogula</span> — a Full Stack Developer with <span className="font-bold">4 years</span> of building robust, cloud-native SaaS solutions. Currently shaping Kaseya&apos;s IT ecosystem, I specialize in high-performance <span className="text-blue-600 dark:text-blue-400">APIs</span>, <span className="text-blue-600 dark:text-blue-400">microservices</span>, and <span className="text-blue-600 dark:text-blue-400">end-to-end cloud architectures</span>.
           </p>
-          <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 space-y-3">
+            <ul className="list-disc list-inside text-slate-700 dark:text-slate-300 space-y-3">
             <li>🚀 Expert in <span className="font-bold">Java (Spring Boot)</span>, <span className="font-bold">Python</span>, <span className="font-bold">JavaScript</span>, and <span className="font-bold">GoLang</span>.</li>
             <li>☁️ Hands-on with <span className="font-bold">AWS, Docker, Kubernetes, Terraform</span>, and CI/CD pipelines.</li>
             <li>💻 Built dynamic reporting tools and scalable REST APIs serving <span className="font-bold">200,000+ users</span>.</li>
             <li>🏆 AWS Certified Cloud Practitioner & HashiCorp Terraform Associate.</li>
             <li>🎓 Master&apos;s in Information Technology & Management from UTD.</li>
           </ul>
-          <p className="text-xl text-gray-700 dark:text-gray-300 leading-relaxed">
-            I thrive in Agile teams, bridging backend efficiency with frontend elegance. Let&apos;s connect and craft something impactful together!
-          </p>
+            <p className="text-xl text-slate-700 dark:text-slate-300 leading-relaxed">
+              I thrive in Agile teams, bridging backend efficiency with frontend elegance. Let&apos;s connect and craft something impactful together!
+            </p>
+          </div>
         </div>
-      </div>
-    </motion.section>
+      </motion.section>
   );
 }

--- a/src/app/components/BeyondWork.tsx
+++ b/src/app/components/BeyondWork.tsx
@@ -21,13 +21,13 @@ const travelImages = [
 
 export default function BeyondWork() {
   return (
-    <motion.section
-      id="beyond-work"
-      className="w-full py-16 bg-gray-900 text-white text-center"
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-    >
+      <motion.section
+        id="beyond-work"
+        className="w-full py-16 text-center text-slate-900 dark:text-slate-100"
+        initial={{ opacity: 0, y: 50 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
       {/* 🔹 Title */}
       <motion.h2
         className="text-5xl font-bold mb-8"
@@ -65,8 +65,8 @@ export default function BeyondWork() {
       </div>
 
       {/* 🔹 Text Content Below */}
-      <motion.p
-        className="mt-8 text-lg max-w-3xl mx-auto px-6"
+        <motion.p
+          className="mt-8 text-lg max-w-3xl mx-auto px-6 text-slate-700 dark:text-slate-300"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 1.5 }}

--- a/src/app/components/Certifications.tsx
+++ b/src/app/components/Certifications.tsx
@@ -43,38 +43,38 @@ export default function Certifications() {
   const [expanded, setExpanded] = useState<number | null>(null);
 
   return (
-    <motion.section
-      id="certifications"
-      className="py-32 px-6 text-center bg-white dark:bg-black"
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-    >
-      <h2 className="text-5xl font-bold mb-6 text-black dark:text-white">🎓 Certifications & Achievements</h2>
-      <p className="mt-2 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+      <motion.section
+        id="certifications"
+        className="py-32 px-6 text-center text-slate-900 dark:text-slate-100"
+        initial={{ opacity: 0, y: 50 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        <h2 className="text-5xl font-bold mb-6 text-slate-900 dark:text-white">🎓 Certifications & Achievements</h2>
+        <p className="mt-2 text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
         Continuous learning keeps me ahead in tech. These credentials validate my skills in cloud, DevOps, and software engineering.
       </p>
 
-      <div className="mt-16 grid grid-cols-1 md:grid-cols-2 gap-10 max-w-5xl mx-auto">
-        {certifications.map((cert, index) => (
-          <motion.div
-            key={index}
-            className="p-8 bg-gray-50 dark:bg-gray-900 rounded-2xl shadow transition hover:shadow-lg text-left relative"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8, delay: index * 0.2 }}
-          >
-            <div className="flex items-center space-x-4">
-              <Image src={cert.companyLogo} alt={cert.issuer} width={50} height={50} className="rounded-md" />
-              <div>
-                <h3 className="text-2xl font-semibold text-black dark:text-white">{cert.title}</h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">{cert.issuer}</p>
+        <div className="mt-16 grid grid-cols-1 md:grid-cols-2 gap-10 max-w-5xl mx-auto">
+          {certifications.map((cert, index) => (
+            <motion.div
+              key={index}
+              className="p-8 ios-card rounded-2xl transition hover:shadow-xl text-left relative"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, delay: index * 0.2 }}
+            >
+              <div className="flex items-center space-x-4">
+                <Image src={cert.companyLogo} alt={cert.issuer} width={50} height={50} className="rounded-md" />
+                <div>
+                  <h3 className="text-2xl font-semibold text-slate-900 dark:text-white">{cert.title}</h3>
+                  <p className="text-sm text-slate-500 dark:text-slate-400">{cert.issuer}</p>
+                </div>
               </div>
-            </div>
 
-            {expanded === index && (
-              <p className="mt-4 text-gray-700 dark:text-gray-300">{cert.description}</p>
-            )}
+              {expanded === index && (
+                <p className="mt-4 text-slate-700 dark:text-slate-300">{cert.description}</p>
+              )}
 
             {cert.badge && (
               <div className="mt-4 flex justify-center">

--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -3,44 +3,41 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
 
 export default function Contact() {
   return (
-    <motion.section
-      id="contact"
-      className="py-32 px-6 bg-white dark:bg-black text-center"
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-    >
-      <h2 className="text-5xl font-bold mb-6 text-black dark:text-white">Contact Me</h2>
-      <p className="mt-2 text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
+      <motion.section
+        id="contact"
+        className="py-32 px-6 text-center text-slate-900 dark:text-slate-100"
+        initial={{ opacity: 0, y: 50 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.8 }}
+      >
+        <h2 className="text-5xl font-bold mb-6 text-slate-900 dark:text-white">Contact Me</h2>
+        <p className="mt-2 text-slate-600 dark:text-slate-400 max-w-xl mx-auto">
         Have a project in mind or want to say hello? Fill out the form below and I&apos;ll get back to you as soon as possible.
       </p>
 
-      <form className="mt-12 max-w-2xl mx-auto space-y-6">
-        <input
-          type="text"
-          placeholder="Your Name"
-          className="w-full p-4 border border-gray-300 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white"
-        />
-        <input
-          type="email"
-          placeholder="Your Email"
-          className="w-full p-4 border border-gray-300 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white"
-        />
-        <textarea
-          placeholder="Your Message"
-          rows={5}
-          className="w-full p-4 border border-gray-300 dark:border-gray-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-black dark:focus:ring-white"
-        ></textarea>
-        <button
-          type="submit"
-          className="px-8 py-4 bg-black text-white rounded-full font-semibold hover:bg-gray-900 transition"
-        >
-          Send Message
-        </button>
-      </form>
+        <form className="mt-12 max-w-2xl mx-auto space-y-6">
+          <input
+            type="text"
+            placeholder="Your Name"
+            className="w-full p-4 ios-card rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-100"
+          />
+          <input
+            type="email"
+            placeholder="Your Email"
+            className="w-full p-4 ios-card rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-100"
+          />
+          <textarea
+            placeholder="Your Message"
+            rows={5}
+            className="w-full p-4 ios-card rounded-lg focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-slate-100"
+          ></textarea>
+          <Button type="submit" className="w-full sm:w-auto">Send Message</Button>
+        </form>
     </motion.section>
   );
 }

--- a/src/app/components/Education.tsx
+++ b/src/app/components/Education.tsx
@@ -5,14 +5,14 @@ import Image from "next/image";
 
 export default function Education() {
   return (
-    <motion.section
-      id="education"
-      className="py-20 px-6 text-center relative"
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-    >
-      <h2 className="text-5xl font-bold mb-6">🎓 Education</h2>
+      <motion.section
+        id="education"
+        className="py-20 px-6 text-center relative text-slate-900 dark:text-slate-100"
+        initial={{ opacity: 0, y: 50 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        <h2 className="text-5xl font-bold mb-6 text-slate-900 dark:text-white">🎓 Education</h2>
 
       <div className="flex flex-col md:flex-row items-center justify-center space-y-10 md:space-y-0 md:space-x-10">
         {/* 🔹 UTD Background Image */}
@@ -29,21 +29,21 @@ export default function Education() {
 
         {/* 🔹 Education Details */}
         <div className="w-full md:w-1/2 text-left max-w-2xl">
-          <h3 className="text-2xl font-semibold">Master of Science in Information Technology & Management</h3>
-          <p className="text-gray-500 dark:text-gray-400">University of Texas at Dallas (2022 - 2024)</p>
+            <h3 className="text-2xl font-semibold">Master of Science in Information Technology & Management</h3>
+            <p className="text-slate-500 dark:text-slate-400">University of Texas at Dallas (2022 - 2024)</p>
 
-          <p className="mt-4 text-gray-700 dark:text-gray-300">
+            <p className="mt-4 text-slate-700 dark:text-slate-300">
             Studying at UT Dallas has been a transformative experience, shaping my technical skills and deepening my understanding of scalable cloud architectures, AI-driven solutions, and enterprise software development.
           </p>
 
-          <p className="mt-2 text-gray-700 dark:text-gray-300">
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
             From hands-on capstone projects to collaborating with talented peers, UTD provided me with an innovative and research-driven environment to thrive as a software engineer.
           </p>
 
           {/* 🔹 Relevant Coursework */}
-          <div className="mt-4">
-            <h4 className="text-lg font-semibold">📚 Relevant Coursework:</h4>
-            <ul className="mt-2 text-gray-600 dark:text-gray-400 list-disc list-inside">
+            <div className="mt-4">
+              <h4 className="text-lg font-semibold">📚 Relevant Coursework:</h4>
+              <ul className="mt-2 text-slate-600 dark:text-slate-400 list-disc list-inside">
               <li>Agile Project Management</li>
               <li>Cloud Computing Fundamentals</li>
               <li>Object-Oriented Programming in Python</li>
@@ -54,9 +54,9 @@ export default function Education() {
           </div>
 
           {/* 🔹 Leadership & Achievements */}
-          <div className="mt-6 bg-gray-100 dark:bg-gray-800 p-4 rounded-lg shadow-md">
-            <h4 className="text-lg text-black font-semibold">🏆 Leadership & Achievements</h4>
-            <p className="mt-2 text-gray-700 dark:text-gray-300">
+          <div className="mt-6 ios-card p-4 rounded-lg shadow-md">
+            <h4 className="text-lg text-slate-900 dark:text-white font-semibold">🏆 Leadership & Achievements</h4>
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
               Head of Social Media Team, Lion&apos;s Club (2022 - 2024)
               Directed campaigns that boosted **social media engagement by 40%**, effectively promoting club initiatives.
             </p>

--- a/src/app/components/Experience.tsx
+++ b/src/app/components/Experience.tsx
@@ -4,54 +4,55 @@ import { motion } from "framer-motion";
 
 export default function Experience() {
   return (
-    <motion.section
-      id="experience"
-      className="py-32 px-6 bg-white dark:bg-black text-center"
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-    >
-      <h2 className="text-5xl font-bold mb-6 text-black dark:text-white">Experience</h2>
+      <motion.section
+        id="experience"
+        className="py-32 px-6 text-center text-slate-900 dark:text-slate-100"
+        initial={{ opacity: 0, y: 50 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.8 }}
+      >
+        <h2 className="text-5xl font-bold mb-6 text-slate-900 dark:text-white">Experience</h2>
       <div className="mt-16 max-w-5xl mx-auto text-left space-y-12">
-        {/* Experience 1 - Kaseya */}
-        <div className="p-10 bg-gray-50 dark:bg-gray-900 rounded-2xl shadow transition hover:shadow-lg">
-          <h3 className="text-2xl font-semibold mb-2 text-black dark:text-white">
+        {/* Experience 1 - Escape 360 Cafe */}
+        <motion.div
+          className="p-10 ios-card rounded-2xl transition hover:shadow-xl"
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+        >
+          <h3 className="text-2xl font-semibold mb-2 text-slate-900 dark:text-white">
             Full Stack Developer
           </h3>
-          <p className="text-gray-600 dark:text-gray-400">
-            Kaseya, Red Bank, NJ | July 2024 – Present
+          <p className="text-slate-600 dark:text-slate-400">
+            Escape 360 Cafe | Jun 2023 – Jan 2024
           </p>
-          <ul className="mt-6 text-gray-700 dark:text-gray-300 list-disc list-inside space-y-2">
-            <li>Managed user verification system using Spring Boot and microservices, deployed via Docker, Jenkins, and Kubernetes on AWS.</li>
-            <li>Improved API response time by 25% and reduced server load by 30% using Node.js and Express.js.</li>
-            <li>Built high-performance REST APIs with Java and Spring Boot, enforced integrity through JUnit-based testing.</li>
-            <li>Maintained Flask and Django backend services to streamline frontend-backend data exchange.</li>
-            <li>Streamlined CI/CD pipelines and Kubernetes deployments with Python and Jenkins tools.</li>
-            <li>Developed responsive single-page applications with React.js and Redux for enhanced UX.</li>
-            <li>Optimized IoT cloud app design with Webpack, Babel, and AWS integrations, cutting load times by 20%.</li>
-            <li>Ensured application scalability and uptime by deploying on AWS with API Gateway support.</li>
-            <li>Revamped Python and Golang content with SPA and RWD principles, improving customer retention by 25%.</li>
+          <ul className="mt-6 text-slate-700 dark:text-slate-300 list-disc list-inside space-y-2">
+            <li>Built a full-stack ordering platform with React, Node.js and MongoDB, powering online and in-store sales.</li>
+            <li>Implemented real-time order tracking and an admin dashboard, cutting fulfillment time by 20%.</li>
+            <li>Designed a mobile-first, glassy UI with Tailwind CSS for a seamless customer experience.</li>
+            <li>Dockerized services and deployed on AWS for reliable, scalable operation.</li>
           </ul>
-        </div>
+        </motion.div>
 
-        {/* Experience 2 - Hexaware */}
-        <div className="p-10 bg-gray-50 dark:bg-gray-900 rounded-2xl shadow transition hover:shadow-lg">
-          <h3 className="text-2xl font-semibold mb-2 text-black dark:text-white">
-            Software Developer
+        {/* Experience 2 - Xnode AI */}
+        <motion.div
+          className="p-10 ios-card rounded-2xl transition hover:shadow-xl"
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+        >
+          <h3 className="text-2xl font-semibold mb-2 text-slate-900 dark:text-white">
+            Software Development Engineer
           </h3>
-          <p className="text-gray-600 dark:text-gray-400">
-            Hexaware Technologies, Bengaluru, India | Nov 2020 – Jul 2022
+          <p className="text-slate-600 dark:text-slate-400">
+            Xnode AI | Feb 2024 – May 2024
           </p>
-          <ul className="mt-6 text-gray-700 dark:text-gray-300 list-disc list-inside space-y-2">
-            <li>Built Mosaic Cloud Platform modules with Angular, Python, and Scala, improving system performance by 40%.</li>
-            <li>Developed responsive UIs using React, Next.js, and Redux, cutting load times by 9%.</li>
-            <li>Created optimized RESTful APIs with Node.js, improving response speed by 25%.</li>
-            <li>Established Postman-based test framework with 95% automation coverage.</li>
-            <li>Modernized UI to meet WCAG 2.1 standards using Angular and Bootstrap.</li>
-            <li>Integrated AWS & Azure cloud services for scalable deployment.</li>
-            <li>Automated pipelines using Terraform, Jenkins, and Kubernetes, enabling zero-downtime releases.</li>
-            <li>Scaled high-traffic e-commerce platform using Docker and Kafka.</li>
+          <ul className="mt-6 text-slate-700 dark:text-slate-300 list-disc list-inside space-y-2">
+            <li>Developed Next.js features for an AI analytics platform used by early enterprise adopters.</li>
+            <li>Created TypeScript APIs connecting front-end dashboards with Python-based inference services.</li>
+            <li>Collaborated in an agile team to introduce automated testing and GitHub Actions CI.</li>
+            <li>Optimized React state management and caching, improving page load times by 15%.</li>
           </ul>
-        </div>
+        </motion.div>
       </div>
     </motion.section>
   );

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -3,8 +3,8 @@
 import { motion } from "framer-motion";
 
 export default function Footer() {
-  return (
-    <footer className="bg-black text-white py-20 px-6 text-center">
+    return (
+      <footer className="py-20 px-6 text-center text-slate-900 dark:text-slate-100">
       <motion.div
         id="contact"
         className="max-w-4xl mx-auto"
@@ -13,7 +13,7 @@ export default function Footer() {
         transition={{ duration: 0.8 }}
       >
         <h2 className="text-5xl font-bold mb-4">Let&apos;s Connect</h2>
-        <p className="mt-2 text-gray-400 max-w-2xl mx-auto">
+          <p className="mt-2 text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
           Open to exciting opportunities and meaningful collaborations. Drop me a line!
         </p>
 
@@ -44,17 +44,17 @@ export default function Footer() {
 
         {/* Optional Map */}
         <div className="mt-12">
-          <iframe
-            title="Location Map"
-            className="w-full max-w-lg h-72 mx-auto rounded-xl shadow-lg"
-            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3344.3883288177385!2d-96.7970!3d32.7767!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x864e9910c52a47fb%3A0xe6a8df9f0e3fef5a!2sDallas%2C%20TX!5e0!3m2!1sen!2sus!4v1647831369185!5m2!1sen!2sus"
-            allowFullScreen
-            loading="lazy"
-          ></iframe>
+            <iframe
+              title="Location Map"
+              className="w-full max-w-lg h-72 mx-auto rounded-xl shadow-lg ios-card"
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3344.3883288177385!2d-96.7970!3d32.7767!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x864e9910c52a47fb%3A0xe6a8df9f0e3fef5a!2sDallas%2C%20TX!5e0!3m2!1sen!2sus!4v1647831369185!5m2!1sen!2sus"
+              allowFullScreen
+              loading="lazy"
+            ></iframe>
         </div>
 
         {/* Copyright */}
-        <div className="mt-10 text-gray-500 text-sm">
+          <div className="mt-10 text-slate-500 text-sm">
           © {new Date().getFullYear()} Rakshith Roy | All Rights Reserved
         </div>
       </motion.div>

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -10,10 +10,19 @@ export default function Hero() {
       {/* Hero Section */}
       <section
         id="hero"
-        className="relative flex flex-col items-center justify-center h-screen px-6 text-center overflow-hidden bg-gradient-to-b from-black to-gray-900"
+        className="relative flex flex-col items-center justify-center h-screen px-6 text-center overflow-hidden"
       >
+        <motion.div
+          className="absolute -top-32 -left-32 w-96 h-96 bg-blue-300 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob"
+        />
+        <motion.div
+          className="absolute top-0 -right-32 w-96 h-96 bg-pink-300 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-2000"
+        />
+        <motion.div
+          className="absolute -bottom-32 left-20 w-96 h-96 bg-purple-300 rounded-full mix-blend-multiply filter blur-3xl opacity-70 animate-blob animation-delay-4000"
+        />
         <motion.h1
-          className="text-6xl md:text-8xl font-semibold text-white tracking-tight"
+          className="text-6xl md:text-8xl font-semibold text-slate-900 dark:text-white tracking-tight"
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 1 }}
@@ -21,7 +30,7 @@ export default function Hero() {
           Rakshith Roy
         </motion.h1>
         <motion.p
-          className="mt-6 text-xl md:text-2xl text-gray-300 max-w-xl"
+          className="mt-6 text-xl md:text-2xl text-slate-700 dark:text-gray-300 max-w-xl"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 1.2 }}
@@ -29,27 +38,24 @@ export default function Hero() {
           Crafting scalable systems & elegant digital experiences.
         </motion.p>
         <div className="mt-10 flex flex-col sm:flex-row gap-4">
-          <a href="#projects">
-            <Button className="px-8 py-4 bg-white text-black font-semibold rounded-full hover:bg-gray-200">
-              See My Work
-            </Button>
-          </a>
-          <a href="#contact">
-            <Button className="px-8 py-4 bg-transparent border border-white text-white font-semibold rounded-full hover:bg-white hover:text-black">
-              Contact Me
-            </Button>
-          </a>
+          <Button href="#projects">See My Work</Button>
+          <Button
+            href="#contact"
+            className="bg-transparent dark:bg-transparent border border-slate-900/20 dark:border-slate-100/20 hover:bg-white/40 dark:hover:bg-gray-800/40"
+          >
+            Contact Me
+          </Button>
         </div>
-        <span className="absolute bottom-10 text-white/70 animate-bounce">↓ Scroll</span>
+        <span className="absolute bottom-10 text-slate-700 dark:text-white/70 animate-bounce">↓ Scroll</span>
       </section>
 
       {/* About Me Section */}
       <section
         id="about"
-        className="flex flex-col items-center justify-center py-32 px-6 bg-white text-black text-center"
+        className="flex flex-col items-center justify-center py-32 px-6 text-center text-slate-900 dark:text-slate-100"
       >
         <h2 className="text-4xl md:text-5xl font-bold mb-4">About Me</h2>
-        <p className="max-w-2xl text-lg md:text-xl text-gray-700">
+          <p className="max-w-2xl text-lg md:text-xl text-slate-700 dark:text-slate-300">
           I&apos;m a Software Engineer driven by curiosity and a love for elegant code.
           My passion lies in building robust cloud systems and exploring AI-driven solutions.
         </p>
@@ -58,15 +64,15 @@ export default function Hero() {
       {/* Featured Projects Section */}
       <section
         id="featured-projects"
-        className="flex flex-col items-center justify-center py-32 px-6 bg-gray-100 text-black text-center"
+        className="flex flex-col items-center justify-center py-32 px-6 text-center text-slate-900 dark:text-slate-100"
       >
         <h2 className="text-4xl md:text-5xl font-bold mb-4">Featured Projects</h2>
-        <p className="max-w-2xl text-lg md:text-xl text-gray-700">
+        <p className="max-w-2xl text-lg md:text-xl text-slate-700 dark:text-slate-300">
           A glimpse into some of my most exciting work, blending technology and creativity.
         </p>
-        <a href="#projects" className="mt-8 inline-block text-blue-600 font-semibold underline">
+        <Button href="#projects" className="mt-8">
           View All Projects
-        </a>
+        </Button>
       </section>
     </main>
   );

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Link } from "react-scroll";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { Menu, X } from "lucide-react";
 
 export default function Navbar() {
@@ -13,7 +13,7 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="fixed top-0 left-0 w-full bg-white/80 backdrop-blur-md text-black shadow z-50">
+    <nav className="fixed top-0 left-0 w-full bg-white/60 dark:bg-gray-900/60 backdrop-blur-xl border-b border-white/20 dark:border-gray-800/20 text-slate-900 dark:text-slate-100 z-50">
       <div className="max-w-7xl mx-auto px-6 py-4 flex justify-between items-center">
         {/* Logo */}
         <motion.h1
@@ -27,9 +27,14 @@ export default function Navbar() {
 
         {/* Mobile Menu Icon */}
         <div className="md:hidden">
-          <button onClick={toggleMenu}>
+          <motion.button
+            onClick={toggleMenu}
+            className="ios-card p-2 rounded-xl"
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.95 }}
+          >
             {menuOpen ? <X size={28} /> : <Menu size={28} />}
-          </button>
+          </motion.button>
         </div>
 
         {/* Desktop Menu */}
@@ -39,7 +44,7 @@ export default function Navbar() {
               to="about"
               smooth={true}
               duration={500}
-              className="hover:text-gray-700 transition cursor-pointer"
+              className="hover:text-slate-500 dark:hover:text-slate-300 transition cursor-pointer"
             >
               About
             </Link>
@@ -49,7 +54,7 @@ export default function Navbar() {
               to="projects"
               smooth={true}
               duration={500}
-              className="hover:text-gray-700 transition cursor-pointer"
+              className="hover:text-slate-500 dark:hover:text-slate-300 transition cursor-pointer"
             >
               Projects
             </Link>
@@ -59,77 +64,84 @@ export default function Navbar() {
               to="contact"
               smooth={true}
               duration={500}
-              className="hover:text-gray-700 transition cursor-pointer"
+              className="hover:text-slate-500 dark:hover:text-slate-300 transition cursor-pointer"
             >
               Contact
             </Link>
           </li>
           <li>
-            <a
+            <motion.a
               href="/Rakshith_Roy_Resume.pdf"
               download
-              className="bg-black text-white hover:bg-gray-900 px-5 py-2 rounded-full font-medium transition"
+              className="ios-card px-5 py-2 rounded-full font-medium hover:bg-white/80 dark:hover:bg-gray-800/80 transition"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
             >
               Resume
-            </a>
+            </motion.a>
           </li>
         </ul>
       </div>
 
       {/* Mobile Menu */}
-      {menuOpen && (
-        <motion.div
-          className="md:hidden bg-white/90 backdrop-blur-md w-full py-6 px-6 absolute top-16 left-0"
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3 }}
-        >
-          <ul className="flex flex-col space-y-4 text-lg">
-            <li>
-              <Link
-                to="about"
-                smooth={true}
-                duration={500}
-                className="hover:text-gray-700 transition cursor-pointer"
-                onClick={toggleMenu}
-              >
-                About
-              </Link>
-            </li>
-            <li>
-              <Link
-                to="projects"
-                smooth={true}
-                duration={500}
-                className="hover:text-gray-700 transition cursor-pointer"
-                onClick={toggleMenu}
-              >
-                Projects
-              </Link>
-            </li>
-            <li>
-              <Link
-                to="contact"
-                smooth={true}
-                duration={500}
-                className="hover:text-gray-700 transition cursor-pointer"
-                onClick={toggleMenu}
-              >
-                Contact
-              </Link>
-            </li>
-            <li>
-              <a
-                href="/Rakshith_Roy_Resume.pdf"
-                download
-                className="bg-black text-white hover:bg-gray-900 px-5 py-2 rounded-full font-medium transition block text-center"
-              >
-                Resume
-              </a>
-            </li>
-          </ul>
-        </motion.div>
-      )}
+      <AnimatePresence>
+        {menuOpen && (
+          <motion.div
+            className="md:hidden bg-white/70 dark:bg-gray-900/70 backdrop-blur-xl w-full py-6 px-6 absolute top-16 left-0 border-b border-white/20 dark:border-gray-800/20"
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.3 }}
+          >
+            <ul className="flex flex-col space-y-4 text-lg">
+              <li>
+                <Link
+                  to="about"
+                  smooth={true}
+                  duration={500}
+                  className="hover:text-slate-500 dark:hover:text-slate-300 transition cursor-pointer"
+                  onClick={toggleMenu}
+                >
+                  About
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="projects"
+                  smooth={true}
+                  duration={500}
+                  className="hover:text-slate-500 dark:hover:text-slate-300 transition cursor-pointer"
+                  onClick={toggleMenu}
+                >
+                  Projects
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="contact"
+                  smooth={true}
+                  duration={500}
+                  className="hover:text-slate-500 dark:hover:text-slate-300 transition cursor-pointer"
+                  onClick={toggleMenu}
+                >
+                  Contact
+                </Link>
+              </li>
+              <li>
+                <motion.a
+                  href="/Rakshith_Roy_Resume.pdf"
+                  download
+                  className="ios-card px-5 py-2 rounded-full font-medium transition block text-center hover:bg-white/80 dark:hover:bg-gray-800/80"
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.95 }}
+                >
+                  Resume
+                </motion.a>
+              </li>
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </nav>
   );
 }

--- a/src/app/components/Projects.tsx
+++ b/src/app/components/Projects.tsx
@@ -64,29 +64,30 @@ export default function Projects() {
   return (
     <motion.section
       id="projects"
-      className="py-32 px-6 text-center bg-white dark:bg-black"
+      className="py-32 px-6 text-center"
       initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
       transition={{ duration: 0.8 }}
     >
-      <h2 className="text-5xl font-bold mb-6 text-black dark:text-white">Projects</h2>
-      <p className="mt-2 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+      <h2 className="text-5xl font-bold mb-6 text-slate-900 dark:text-white">Projects</h2>
+      <p className="mt-2 text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
         A showcase of my academic and personal projects demonstrating practical solutions and technical depth.
       </p>
 
       {/* Toggle Button */}
       <div className="mt-10 flex justify-center gap-4">
         <button
-          className={`px-8 py-3 rounded-full text-white font-semibold shadow transition ${
-            showAcademic ? "bg-black dark:bg-white dark:text-black" : "bg-gray-500 hover:bg-gray-600"
+          className={`ios-card px-8 py-3 rounded-full font-semibold transition ${
+            showAcademic ? "" : "opacity-50"
           }`}
           onClick={() => setShowAcademic(true)}
         >
           Academic Projects
         </button>
         <button
-          className={`px-8 py-3 rounded-full text-white font-semibold shadow transition ${
-            !showAcademic ? "bg-black dark:bg-white dark:text-black" : "bg-gray-500 hover:bg-gray-600"
+          className={`ios-card px-8 py-3 rounded-full font-semibold transition ${
+            !showAcademic ? "" : "opacity-50"
           }`}
           onClick={() => setShowAcademic(false)}
         >
@@ -99,21 +100,24 @@ export default function Projects() {
         {(showAcademic ? academicProjects : personalProjects).map((project, index) => (
           <motion.div
             key={index}
-            className="p-8 bg-gray-50 dark:bg-gray-900 rounded-2xl shadow transition hover:shadow-lg text-left"
+            className="p-8 ios-card rounded-2xl transition hover:shadow-xl text-left"
             initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.2 }}
             transition={{ duration: 0.8, delay: index * 0.2 }}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
           >
-            <h3 className="text-2xl font-semibold mb-2 text-black dark:text-white">{project.title}</h3>
+            <h3 className="text-2xl font-semibold mb-2 text-slate-900 dark:text-white">{project.title}</h3>
             {"institution" in project && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{project.institution}</p>
+              <p className="text-sm text-slate-500 dark:text-slate-400 mb-2">{project.institution}</p>
             )}
-            <p className="mb-4 text-gray-700 dark:text-gray-300">{project.description}</p>
+            <p className="mb-4 text-slate-700 dark:text-slate-300">{project.description}</p>
             <div className="flex flex-wrap gap-2 mb-4">
               {project.techStack.map((tech, i) => (
                 <span
                   key={i}
-                  className="px-3 py-1 bg-black text-white dark:bg-white dark:text-black text-xs font-semibold rounded-full"
+                  className="px-3 py-1 ios-card text-xs font-semibold"
                 >
                   {tech}
                 </span>

--- a/src/app/components/Skills.tsx
+++ b/src/app/components/Skills.tsx
@@ -83,43 +83,45 @@ const skills = [
 
 export default function Skills() {
   return (
-    <motion.section
-      id="skills"
-      className="py-32 px-6 text-center bg-white dark:bg-black"
-      initial={{ opacity: 0, y: 50 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-    >
-      <h2 className="text-5xl font-bold mb-6 text-black dark:text-white">Skills & Technologies</h2>
-      <p className="mt-2 text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-        A curated showcase of my technical expertise, honed through real-world projects and industry experience.
-      </p>
+      <motion.section
+        id="skills"
+        className="py-32 px-6 text-center text-slate-900 dark:text-slate-100"
+        initial={{ opacity: 0, y: 50 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.3 }}
+        transition={{ duration: 0.8 }}
+      >
+        <h2 className="text-5xl font-bold mb-6 text-slate-900 dark:text-white">Skills & Technologies</h2>
+        <p className="mt-2 text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
+          A curated showcase of my technical expertise, honed through real-world projects and industry experience.
+        </p>
 
       <div className="mt-16 grid grid-cols-1 md:grid-cols-2 gap-10 max-w-5xl mx-auto">
-        {skills.map((skill, index) => (
-          <div
-            key={index}
-            className="p-8 bg-gray-50 dark:bg-gray-900 rounded-2xl shadow transition hover:shadow-lg"
-          >
-            <h3 className="text-2xl font-semibold mb-6 text-black dark:text-white">{skill.category}</h3>
-            {skill.items.map((item, i) => (
-              <div key={i} className="mb-5">
-                <div className="flex justify-between text-gray-700 dark:text-gray-300 font-medium">
-                  <span>{item.name}</span>
-                  <span>{item.level}%</span>
+          {skills.map((skill, index) => (
+            <div
+              key={index}
+              className="p-8 ios-card rounded-2xl transition hover:shadow-xl"
+            >
+              <h3 className="text-2xl font-semibold mb-6 text-slate-900 dark:text-white">{skill.category}</h3>
+              {skill.items.map((item, i) => (
+                <div key={i} className="mb-5">
+                  <div className="flex justify-between text-slate-700 dark:text-slate-300 font-medium">
+                    <span>{item.name}</span>
+                    <span>{item.level}%</span>
+                  </div>
+                  <div className="mt-2 w-full bg-white/40 dark:bg-gray-800/40 rounded-full h-3 overflow-hidden">
+                    <motion.div
+                      className="h-3 bg-slate-900 dark:bg-slate-100 rounded-full"
+                      initial={{ width: "0%" }}
+                      whileInView={{ width: `${item.level}%` }}
+                      viewport={{ once: true }}
+                      transition={{ duration: 1 }}
+                    />
+                  </div>
                 </div>
-                <div className="mt-2 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
-                  <motion.div
-                    className="h-3 bg-black dark:bg-white rounded-full"
-                    initial={{ width: "0%" }}
-                    animate={{ width: `${item.level}%` }}
-                    transition={{ duration: 1 }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        ))}
+              ))}
+            </div>
+          ))}
       </div>
     </motion.section>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,20 +2,58 @@
 @tailwind components;
 @tailwind utilities;
 
+/* iOS‑style light and dark colour system */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f8fafc;
+  --foreground: #0f172a;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #f1f5f9;
   }
 }
 
 body {
   color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  background-color: var(--background);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Helvetica Neue", Arial, sans-serif;
+  /* subtle radial gradients for a glossy iOS 26 finish */
+  background-image:
+    radial-gradient(at 0% 0%, #e0f2fe 0, transparent 70%),
+    radial-gradient(at 100% 100%, #fbcfe8 0, transparent 70%);
+  background-attachment: fixed;
+}
+
+@layer components {
+  .ios-card {
+    @apply bg-white/30 dark:bg-gray-900/30 backdrop-blur-xl border border-white/20 dark:border-gray-800/30 shadow-lg rounded-3xl transition-all duration-300 hover:shadow-xl;
+  }
+}
+
+@layer utilities {
+  @keyframes blob {
+    0%, 100% {
+      transform: translate(0, 0) scale(1);
+    }
+    33% {
+      transform: translate(30px, -50px) scale(1.1);
+    }
+    66% {
+      transform: translate(-20px, 20px) scale(0.9);
+    }
+  }
+
+  .animate-blob {
+    animation: blob 20s infinite;
+  }
+
+  .animation-delay-2000 {
+    animation-delay: 2s;
+  }
+
+  .animation-delay-4000 {
+    animation-delay: 4s;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white text-black min-h-screen`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen text-slate-900 dark:text-slate-100`}
       >
         {children}
       </body>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,16 +1,41 @@
 import React from "react";
+import { motion } from "framer-motion";
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children: React.ReactNode;
+  href?: string;
 }
 
-export const Button: React.FC<ButtonProps> = ({ children, ...props }) => {
+export const Button: React.FC<ButtonProps> = ({
+  children,
+  className = "",
+  href,
+  ...props
+}) => {
+  if (href) {
+    return (
+      <motion.a
+        href={href}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+        className={`ios-card px-8 py-4 rounded-full font-semibold transition hover:bg-white/80 dark:hover:bg-gray-800/80 ${className}`}
+        {...props}
+      >
+        {children}
+      </motion.a>
+    );
+  }
+
   return (
-    <button
-      className="px-8 py-4 bg-black text-white font-semibold rounded-full hover:bg-gray-900 transition"
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      className={`ios-card px-8 py-4 rounded-full font-semibold transition hover:bg-white/80 dark:hover:bg-gray-800/80 ${className}`}
       {...props}
     >
       {children}
-    </button>
+    </motion.button>
   );
 };


### PR DESCRIPTION
## Summary
- Replace placeholder work history with Escape 360 Cafe full-stack role and Xnode AI SDE internship
- Allow buttons to act as links and update hero/featured project calls-to-action for working navigation
- Lighten shared iOS card styling and add animated gradient blobs for a more pronounced glassy hero

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955e5e66e8832fad83e496566e9d26